### PR TITLE
Add gitops pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Instructions on how to install and setup a concourse pipeline can be found in [c
 `gitops-apply, gitops-template.yaml`: Add this to [environments repository](https://github.com/ministryofjustice/cloud-platform-environments) to iterate the namespaces and to setup individual pipeline for user repo .
 
 `gitops-deploy-template`: This is the sample template which should be placed in the user repo. This should have the command to deploy the user code into the cloud platform cluster.
+
+Note: This spike was tested with a look alike of environments repo and  was not tested with the actual [environments repository](https://github.com/ministryofjustice/cloud-platform-environments)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# cloud-platform-gitops-spike
+# Cloud platform gitops spike
+This is the spike to us concourse as a gitops solution
+
+Instructions on how to install and setup a concourse pipeline can be found in [cloud platform concourse repo](https://github.com/ministryofjustice/cloud-platform-concourse)
+
+`gitops-apply, gitops-template.yaml`: Add this to [environments repository](https://github.com/ministryofjustice/cloud-platform-environments) to iterate the namespaces and to setup individual pipeline for user repo .
+
+`gitops-deploy-template`: This is the sample template which should be placed in the user repo. This should have the command to deploy the user code into the cloud platform cluster.

--- a/build-environments-gitops.yaml
+++ b/build-environments-gitops.yaml
@@ -8,10 +8,10 @@
 #   footer: concourse.cloud-platform.service.justice.gov.uk
 
 resources:
-- name: vijay-veeranki-helloworld-repo
+- name: cloud-platform-environments-repo
   type: git
   source:
-    uri: https://github.com/vijay-veeranki-moj/helloworld.git
+    uri: https://github.com/ministryofjustice/cloud-platform-environments.git
     branch: master
     # git_crypt_key: ((cloud-platform-environments-git-crypt.key))
 - name: tools-image
@@ -48,7 +48,7 @@ jobs:
       - aggregate:
         - get: every-30m
           trigger: true
-        - get: vijay-veeranki-helloworld-repo
+        - get: cloud-platform-environments-repo
           trigger: true
         - get: tools-image
       - task: apply-environments
@@ -56,7 +56,7 @@ jobs:
         config:
           platform: linux
           inputs:
-            - name: vijay-veeranki-helloworld-repo
+            - name: cloud-platform-environments-repo
           params:
             AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
             AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
@@ -78,7 +78,7 @@ jobs:
             CONCOURSE_BASIC_AUTH_PASSWORD: ((concourse-basic-auth.password))
           run:
             path: /bin/sh
-            dir: vijay-veeranki-helloworld-repo
+            dir: cloud-platform-environments-repo
             args:
               - -c
               - |

--- a/build-environments-gitops.yaml
+++ b/build-environments-gitops.yaml
@@ -1,0 +1,97 @@
+# slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+#   channel: '#cloud-platform-notify'
+#   silent: true
+# slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+#   fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+#   title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+#   title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+#   footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+- name: vijay-veeranki-helloworld-repo
+  type: git
+  source:
+    uri: https://github.com/vijay-veeranki-moj/helloworld.git
+    branch: master
+    # git_crypt_key: ((cloud-platform-environments-git-crypt.key))
+- name: tools-image
+  type: docker-image
+  source:
+    repository: ministryofjustice/cloud-platform-tools
+    tag: 1.1
+# - name: slack-alert
+#   type: slack-notification
+#   source:
+#     url: https://hooks.slack.com/services/((slack-hook-id))
+- name: every-30m
+  type: time
+  source:
+    interval: 30m
+
+resource_types:
+# - name: slack-notification
+#   type: docker-image
+#   source:
+#     repository: cfcommunity/slack-notification-resource
+#     tag: latest
+
+groups:
+# - name: live-0
+#   jobs: [apply-live-0]
+- name: gitops
+  jobs: [apply-gitops]
+
+jobs:
+  - name: apply-gitops
+    serial: true
+    plan:
+      - aggregate:
+        - get: every-30m
+          trigger: true
+        - get: vijay-veeranki-helloworld-repo
+          trigger: true
+        - get: tools-image
+      - task: apply-environments
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: vijay-veeranki-helloworld-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
+            KUBECONFIG_AWS_ACCESS_KEY_ID: ((aws-live-1.access-key-id))
+            KUBECONFIG_AWS_SECRET_ACCESS_KEY: ((aws-live-1.secret-access-key))
+            KUBECONFIG: /tmp/kubeconfig
+            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            PIPELINE_CLUSTER: pk-test-9.cloud-platform.service.justice.gov.uk
+            PIPELINE_STATE_BUCKET: cloud-platform-terraform-state
+            PIPELINE_STATE_KEY_PREFIX: "vijay-veeranki-moj/"
+            PIPELINE_STATE_REGION: "eu-west-1"
+            PIPELINE_CLUSTER_STATE_BUCKET: cloud-platform-terraform-state
+            PIPELINE_CLUSTER_STATE_KEY_PREFIX: "cloud-platform/"
+            CONCOURSE_FLY_VERSION: 5.5.0
+            CONCOURSE_URL: 'http://concourse-web.concourse.svc.cluster.local:8080'
+            CONCOURSE_TEAM: main
+            CONCOURSE_CLUSTER: live-1
+            CONCOURSE_BASIC_AUTH_USERNAME: ((concourse-basic-auth.username))
+            CONCOURSE_BASIC_AUTH_PASSWORD: ((concourse-basic-auth.password))
+          run:
+            path: /bin/sh
+            dir: vijay-veeranki-helloworld-repo
+            args:
+              - -c
+              - |
+                mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+                  AWS_ACCESS_KEY_ID="${KUBECONFIG_AWS_ACCESS_KEY_ID}"
+                  AWS_SECRET_ACCESS_KEY="${KUBECONFIG_AWS_SECRET_ACCESS_KEY}"
+                  aws s3 cp s3://cloud-platform-pk-test-9-kubecfg/kubeconfig /tmp/kubeconfig
+                chmod 777 ./gitops-apply
+                ./gitops-apply
+        on_failure:
+          # put: slack-alert
+          # params:
+          #   <<: *SLACK_NOTIFICATION_DEFAULTS
+          #   attachments:
+          #     - color: "danger"
+          #       <<: *SLACK_ATTACHMENTS_DEFAULTS

--- a/gitops-apply
+++ b/gitops-apply
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# shellcheck source=.common.sh
+# source "$(dirname ${BASH_SOURCE[0]})/.common.sh"
+
+log() {
+  _fg=''
+  [ "${1}" = "red" ] && _fg='\033[0;31m'
+  [ "${1}" = "blue" ] && _fg='\033[0;34m'
+  [ "${1}" = "green" ] && _fg='\033[0;32m'
+  shift
+  # shellcheck disable=SC2145
+  echo -e "${_fg}>>> ${@}\033[0m"
+}
+
+cluster="${PIPELINE_CLUSTER}"
+
+
+echo ${cluster}
+log green "applying for cluster ${cluster}"
+( set -x; kubectl config use-context "${cluster}" ) || { log red "no context found, skipping ${cluster}" && exit 1; }
+for _f in namespaces/vij-argocd.cloud-platform.service.justice.gov.uk/*; do
+  if [ -d "${_f}" ]; then
+    namespace="$(basename ${_f})"
+    log blue "applying resources for namespace ${namespace} in ${cluster}"
+    # set the uri 
+    # get the token and ca, create a config file and push to s3
+    set +x;
+    repourl=$(kubectl get ns ${namespace} -o json | jq -r '.metadata.annotations["cloud-platform.justice.gov.uk/source-code"]')
+    serviceaccounttoken=$(kubectl -n ${namespace} get secret $(kubectl -n ${namespace} get serviceaccount gitops-${namespace} -o jsonpath='{.secrets[0].name}') -o jsonpath='{.data.token}' | base64 --decode)
+    servercadata=$(kubectl get secrets -n ${namespace}  $(kubectl -n ${namespace} get serviceaccount gitops-${namespace} -o jsonpath='{.secrets[0].name}') -o jsonpath='{.data.ca\.crt}')
+    
+    cat > kubeconfig <<EOF
+    apiVersion: v1
+    kind: Config
+    users:
+    - name: ${namespace}
+      user:
+        token: ${serviceaccounttoken}
+    clusters:
+    - cluster:
+        certificate-authority-data: ${servercadata}
+        server: https://api.${cluster}
+      name: ${cluster}
+    contexts:
+    - context:
+        cluster: ${cluster}
+        user: ${namespace}
+      name: ${cluster}
+    current-context: ${cluster}
+EOF
+
+   log green "Copying kubeconfig file for ${namespace} in to s3 bucket"
+
+    aws s3 cp kubeconfig s3://cloud-platform-pk-test-9-kubecfg/kubeconfig-${namespace}
+    
+    set -x; 
+    apk add \
+      --no-cache \
+      --no-progress \
+      curl \
+      tar
+
+    curl -Ls "https://github.com/concourse/concourse/releases/download/v${CONCOURSE_FLY_VERSION}/fly-${CONCOURSE_FLY_VERSION}-linux-amd64.tgz" | tar zxf - -C /usr/local/bin
+
+    fly \
+      -t current \
+      login \
+      -k \
+      -c ${CONCOURSE_URL} \
+      -n ${CONCOURSE_TEAM} \
+      -u ${CONCOURSE_BASIC_AUTH_USERNAME} \
+      -p ${CONCOURSE_BASIC_AUTH_PASSWORD}
+    
+    fly -t current sync
+    echo ">>> setting pipeline '${namespace}'"
+    (
+      set +x
+      fly \
+        -t current \
+        set-pipeline \
+        -n \
+        -p "${namespace}" \
+        -c "./gitops-template.yaml" \
+        --var "repo-url=${repourl}" \
+        --var "namespace=${namespace}"
+    )
+  fi
+done

--- a/gitops-deploy-template
+++ b/gitops-deploy-template
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+log() {
+  _fg=''
+  [ "${1}" = "red" ] && _fg='\033[0;31m'
+  [ "${1}" = "blue" ] && _fg='\033[0;34m'
+  [ "${1}" = "green" ] && _fg='\033[0;32m'
+  shift
+  # shellcheck disable=SC2145
+  echo -e "${_fg}>>> ${@}\033[0m"
+}
+
+
+log green "applying kubectl in cluster ${PIPELINE_CLUSTER}"
+
+kubectl apply -f cp-deploy/kubectl-deploy/ --namespace=${NAMESPACE}
+
+
+# log green "applying helm in cluster ${PIPELINE_CLUSTER}"
+
+# helm install --name example cp-deploy/helm-deploy/ --namespace=live0-to-live1
+
+# helm install cp-deploy/helm-deploy/ \
+#       --tiller-namespace ${NAMESPACE} \
+#       --namespace ${NAMESPACE}
+
+

--- a/gitops-template.yaml
+++ b/gitops-template.yaml
@@ -1,0 +1,87 @@
+# slack-notification-defaults: &SLACK_NOTIFICATION_DEFAULTS
+#   channel: '#cloud-platform-notify'
+#   silent: true
+# slack-attachments-defaults: &SLACK_ATTACHMENTS_DEFAULTS
+#   fallback: 'Finished building $BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+#   title: '$BUILD_TEAM_NAME/$BUILD_PIPELINE_NAME/$BUILD_JOB_NAME#$BUILD_NAME'
+#   title_link: 'https://concourse.cloud-platform.service.justice.gov.uk/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME'
+#   footer: concourse.cloud-platform.service.justice.gov.uk
+
+resources:
+  - name: ((namespace))-repo
+    type: git
+    source:
+      uri: ((repo-url))
+      branch: master
+      # git_crypt_key: ((repo-url))
+  - name: tools-image
+    type: docker-image
+    source:
+      repository: ministryofjustice/cloud-platform-tools
+      tag: 1.1
+  # - name: slack-alert
+  #   type: slack-notification
+  #   source:
+  #     url: https://hooks.slack.com/services/((slack-hook-id))
+  - name: every-30m
+    type: time
+    source:
+      interval: 30m
+
+resource_types:
+# - name: slack-notification
+#   type: docker-image
+#   source:
+#     repository: cfcommunity/slack-notification-resource
+#     tag: latest
+
+groups:
+  - name: template-gitops
+    jobs: [namespace-gitops]
+
+jobs:
+  - name: namespace-gitops
+    serial: true
+    plan:
+      - aggregate:
+          - get: every-30m
+            trigger: true
+          - get: ((namespace))-repo
+            trigger: true
+          - get: tools-image
+      - task: apply-environments
+        image: tools-image
+        config:
+          platform: linux
+          inputs:
+            - name: ((namespace))-repo
+          params:
+            AWS_ACCESS_KEY_ID: ((aws-pk-test-9.access-key-id))
+            AWS_SECRET_ACCESS_KEY: ((aws-pk-test-9.secret-access-key))
+            TF_PLUGIN_CACHE_DIR: /tmp/terraform-plugin-cache
+            KUBECONFIG: /tmp/kubeconfig
+            # the variables prefixed with PIPELINE_ are used by the apply script
+            PIPELINE_CLUSTER: pk-test-9.cloud-platform.service.justice.gov.uk
+            KUBECONFIG: /tmp/kubeconfig
+            PIPELINE_STATE_REGION: "eu-west-1"
+            NAMESPACE: ((namespace))
+          run:
+            path: /bin/sh
+            dir: ((namespace))-repo
+            args:
+              - -c
+              - |
+                mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+                aws s3 cp s3://cloud-platform-pk-test-9-kubecfg/kubeconfig-${NAMESPACE} /tmp/kubeconfig
+                export KUBECONFIG=${KUBECONFIG}
+                kubectl config use-context ${PIPELINE_CLUSTER}
+                kubectl get secrets -n ${NAMESPACE}
+                chmod +x ./gitops-deploy
+                ./gitops-deploy
+        on_failure:
+          # put: slack-alert
+          # params:
+          #   <<: *SLACK_NOTIFICATION_DEFAULTS
+          #   attachments:
+          #     - color: "danger"
+          #       <<: *SLACK_ATTACHMENTS_DEFAULTS


### PR DESCRIPTION
Related to: https://github.com/ministryofjustice/cloud-platform/issues/1276 and 
https://github.com/ministryofjustice/cloud-platform/issues/1272

What and Why:
Code developed to create a gitops spike using Concourse. Use customised shell script to iterating through namespaces automatically create pipelines to deploying code from specific file in users repo.